### PR TITLE
Fixed default length

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,7 +1,7 @@
 import random from "./random.ts";
 import url from "./url.ts";
 
-export const nanoid = (size: number = 12): string => {
+export const nanoid = (size: number = 21): string => {
   let id: string = "";
   const bytes: Uint32Array = random(size);
   // Compact alternative for `for (var i = 0; i < size; i++)`


### PR DESCRIPTION
Original implementation and the readme say the default length of an ID is 21 characters